### PR TITLE
Enhance inspections and transformers with favorite support, dialog components, and style refactor

### DIFF
--- a/transformer-api/src/main/java/com/teambackslash/transformer_api/dto/InspectionDTO.java
+++ b/transformer-api/src/main/java/com/teambackslash/transformer_api/dto/InspectionDTO.java
@@ -9,6 +9,7 @@ public class InspectionDTO {
     private LocalDateTime inspectionTime;
     private String branch;
     private String inspector;
+    private Boolean favorite;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 

--- a/transformer-api/src/main/java/com/teambackslash/transformer_api/entity/Inspection.java
+++ b/transformer-api/src/main/java/com/teambackslash/transformer_api/entity/Inspection.java
@@ -30,6 +30,9 @@ public class Inspection {
     @Column(name = "inspector", nullable = false, length = 100)
     private String inspector;
 
+    @Column(name = "favorite", nullable = false)
+    private boolean favorite = false;
+
     @OneToOne(mappedBy = "inspection", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @JsonManagedReference
     private Image image;

--- a/transformer-api/src/main/java/com/teambackslash/transformer_api/service/InspectionService.java
+++ b/transformer-api/src/main/java/com/teambackslash/transformer_api/service/InspectionService.java
@@ -75,6 +75,7 @@ public class InspectionService {
                 }
                 case "branch"    -> inspection.setBranch((String) value);
                 case "inspector" -> inspection.setInspector((String) value);
+                case "favorite"  -> inspection.setFavorite((Boolean) value);
                 case "transformerNo" -> {
                     String tNo = (String) value;
                     Transformer transformer = transformerRepository.findById(tNo)

--- a/transformer-api/src/main/resources/data.sql
+++ b/transformer-api/src/main/resources/data.sql
@@ -10,23 +10,23 @@ VALUES
 
 -- ===== Baseline + extra inspections (fixed IDs; idempotent) =====
 INSERT IGNORE INTO inspection
-  (inspection_id, transformer_no, inspection_time, branch, inspector, created_at, updated_at)
+  (inspection_id, transformer_no, inspection_time, branch, inspector, created_at, updated_at, favorite)
 VALUES
-(1,'AZ-8801','2024-01-15 09:30:00','Nugegoda','System', NOW(), NOW()),
-(2,'AZ-8802','2024-01-15 10:00:00','Maharagama','System', NOW(), NOW()),
-(3,'AZ-8803','2024-01-15 10:30:00','Kotte','System', NOW(), NOW()),
-(4,'AZ-8804','2024-01-15 11:00:00','Dehiwala','System', NOW(), NOW()),
-(5,'AZ-8805','2024-01-15 11:30:00','Nugegoda','System', NOW(), NOW()),
-(6,'AZ-8801','2024-01-20 09:30:00','Nugegoda','System', NOW(), NOW()),
-(7,'AZ-8802','2024-01-20 10:00:00','Maharagama','System', NOW(), NOW()),
-(8,'AZ-8803','2024-01-20 10:30:00','Kotte','System', NOW(), NOW()),
-(9,'AZ-8804','2024-01-20 11:00:00','Dehiwala','System', NOW(), NOW()),
-(10,'AZ-8805','2024-01-20 11:30:00','Nugegoda','System', NOW(), NOW()),
-(11,'AZ-8801','2024-01-25 09:30:00','Nugegoda','System', NOW(), NOW()),
-(12,'AZ-8802','2024-01-25 10:00:00','Maharagama','System', NOW(), NOW()),
-(13,'AZ-8803','2024-01-25 10:30:00','Kotte','System', NOW(), NOW()),
-(14,'AZ-8804','2024-01-25 11:00:00','Dehiwala','System', NOW(), NOW()),
-(15,'AZ-8805','2024-01-25 11:30:00','Nugegoda','System', NOW(), NOW());
+(1,'AZ-8801','2024-01-15 09:30:00','Nugegoda','System', NOW(), NOW(), 0),
+(2,'AZ-8802','2024-01-15 10:00:00','Maharagama','System', NOW(), NOW(), 0),
+(3,'AZ-8803','2024-01-15 10:30:00','Kotte','System', NOW(), NOW(), 0),
+(4,'AZ-8804','2024-01-15 11:00:00','Dehiwala','System', NOW(), NOW(), 0),
+(5,'AZ-8805','2024-01-15 11:30:00','Nugegoda','System', NOW(), NOW(), 0),
+(6,'AZ-8801','2024-01-20 09:30:00','Nugegoda','System', NOW(), NOW(), 0),
+(7,'AZ-8802','2024-01-20 10:00:00','Maharagama','System', NOW(), NOW(), 0),
+(8,'AZ-8803','2024-01-20 10:30:00','Kotte','System', NOW(), NOW(), 0),
+(9,'AZ-8804','2024-01-20 11:00:00','Dehiwala','System', NOW(), NOW(), 0),
+(10,'AZ-8805','2024-01-20 11:30:00','Nugegoda','System', NOW(), NOW(), 0),
+(11,'AZ-8801','2024-01-25 09:30:00','Nugegoda','System', NOW(), NOW(), 0),
+(12,'AZ-8802','2024-01-25 10:00:00','Maharagama','System', NOW(), NOW(), 0),
+(13,'AZ-8803','2024-01-25 10:30:00','Kotte','System', NOW(), NOW(), 0),
+(14,'AZ-8804','2024-01-25 11:00:00','Dehiwala','System', NOW(), NOW(), 0),
+(15,'AZ-8805','2024-01-25 11:30:00','Nugegoda','System', NOW(), NOW(), 0);
 
 -- ===== Images (one per inspection; omit image_id so AUTO_INCREMENT is used) =====
 INSERT IGNORE INTO image

--- a/transformer-dashboard/src/models/AddEditTransformerDialog.tsx
+++ b/transformer-dashboard/src/models/AddEditTransformerDialog.tsx
@@ -1,0 +1,252 @@
+import * as React from "react";
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+
+// Types matching the Dashboard component
+export type TransformerType = "Bulk" | "Distribution";
+
+export interface Transformer {
+  id?: number;
+  transformerNo: string;
+  poleNo: string;
+  region: string;
+  type: TransformerType;
+  favorite?: boolean;
+  location?: string;
+}
+
+export interface TransformerFormData {
+  region: string;
+  transformerNo: string;
+  poleNo: string;
+  type: TransformerType | "";
+  location: string;
+}
+
+export interface AddTransformerDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSave: (transformer: TransformerFormData, isEdit: boolean) => Promise<void>;
+  transformer?: Transformer | null; // If provided, this is an edit operation
+  regions: readonly string[];
+  types: TransformerType[];
+  isSaving?: boolean;
+}
+
+export const AddTransformerDialog: React.FC<AddTransformerDialogProps> = ({
+  open,
+  onClose,
+  onSave,
+  transformer,
+  regions,
+  types,
+  isSaving = false,
+}) => {
+  const isEdit = !!transformer;
+
+  // Form state
+  const [form, setForm] = React.useState<TransformerFormData>({
+    region: "",
+    transformerNo: "",
+    poleNo: "",
+    type: "",
+    location: "",
+  });
+
+  // Error state
+  const [errors, setErrors] = React.useState<{ [k: string]: boolean }>({});
+
+  // Initialize form when dialog opens with transformer data
+  React.useEffect(() => {
+    if (open) {
+      if (transformer) {
+        setForm({
+          region: transformer.region,
+          transformerNo: transformer.transformerNo,
+          poleNo: transformer.poleNo,
+          type: transformer.type,
+          location: transformer.location || "",
+        });
+      } else {
+        setForm({
+          region: "",
+          transformerNo: "",
+          poleNo: "",
+          type: "",
+          location: "",
+        });
+      }
+      setErrors({});
+    }
+  }, [open, transformer]);
+
+  const updateField =
+    (k: keyof TransformerFormData) =>
+    (
+      e:
+        | React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+        | React.ChangeEvent<{ value: unknown }>
+        | { target: { value: unknown } }
+    ) =>
+      setForm((f) => ({ ...f, [k]: e.target.value }));
+
+  const handleSave = async () => {
+    const newErrors = {
+      region: !form.region,
+      transformerNo: !form.transformerNo,
+      poleNo: !form.poleNo,
+      type: !form.type,
+    };
+
+    setErrors(newErrors);
+    if (Object.values(newErrors).some(Boolean)) return;
+
+    try {
+      await onSave(form, isEdit);
+      handleClose();
+    } catch (error) {
+      // Error handling is done by the parent component
+      console.error("Error saving transformer:", error);
+    }
+  };
+
+  const handleClose = () => {
+    if (!isSaving) {
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} fullWidth maxWidth="sm">
+      <DialogTitle sx={{ pb: 1 }}>
+        {isEdit ? "Edit Transformer" : "Add New Transformer"}
+      </DialogTitle>
+      <DialogContent sx={{ pt: 1 }}>
+        <Stack spacing={2.5} sx={{ mt: 1 }}>
+          <FormControl fullWidth size="small" error={!!errors.region}>
+            <InputLabel id="region-label">Region *</InputLabel>
+            <Select
+              labelId="region-label"
+              label="Region *"
+              value={form.region}
+              onChange={updateField("region")}
+              disabled={isSaving}
+            >
+              {regions.map((r) => (
+                <MenuItem key={r} value={r}>
+                  {r}
+                </MenuItem>
+              ))}
+            </Select>
+            {errors.region && (
+              <Typography
+                variant="caption"
+                color="error"
+                sx={{ mt: 0.5, ml: 1.5 }}
+              >
+                Region is required
+              </Typography>
+            )}
+          </FormControl>
+
+          <TextField
+            size="small"
+            label="Transformer No *"
+            value={form.transformerNo}
+            onChange={updateField("transformerNo")}
+            error={!!errors.transformerNo}
+            helperText={
+              errors.transformerNo ? "Transformer number is required" : ""
+            }
+            fullWidth
+            disabled={isEdit || isSaving} // Disable editing transformer number for existing records
+          />
+
+          <TextField
+            size="small"
+            label="Pole No *"
+            value={form.poleNo}
+            onChange={updateField("poleNo")}
+            error={!!errors.poleNo}
+            helperText={errors.poleNo ? "Pole number is required" : ""}
+            fullWidth
+            disabled={isSaving}
+          />
+
+          <FormControl fullWidth size="small" error={!!errors.type}>
+            <InputLabel id="type-label">Type *</InputLabel>
+            <Select
+              labelId="type-label"
+              label="Type *"
+              value={form.type}
+              onChange={updateField("type")}
+              disabled={isSaving}
+            >
+              {types.map((t) => (
+                <MenuItem key={t} value={t}>
+                  {t}
+                </MenuItem>
+              ))}
+            </Select>
+            {errors.type && (
+              <Typography
+                variant="caption"
+                color="error"
+                sx={{ mt: 0.5, ml: 1.5 }}
+              >
+                Type is required
+              </Typography>
+            )}
+          </FormControl>
+
+          <TextField
+            size="small"
+            label="Location Details"
+            value={form.location}
+            onChange={updateField("location")}
+            fullWidth
+            multiline
+            minRows={3}
+            placeholder="Enter detailed location information..."
+            disabled={isSaving}
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2.5, pt: 1 }}>
+        <Button onClick={handleClose} disabled={isSaving} sx={{ mr: 1 }}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleSave}
+          disabled={isSaving}
+          sx={{
+            minWidth: 100,
+            background: isEdit
+              ? "linear-gradient(180deg, #4F46E5 0%, #2E26C3 100%)"
+              : "linear-gradient(180deg, #4F46E5 0%, #2E26C3 100%)",
+          }}
+        >
+          {isSaving ? (
+            <CircularProgress size={20} color="inherit" />
+          ) : (
+            isEdit ? "Update" : "Add"
+          )}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/transformer-dashboard/src/models/AddInspectionDialog.tsx
+++ b/transformer-dashboard/src/models/AddInspectionDialog.tsx
@@ -1,0 +1,221 @@
+import * as React from "react";
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Close as CloseIcon } from "@mui/icons-material";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import { DatePicker } from "@mui/x-date-pickers/DatePicker";
+import { TimePicker } from "@mui/x-date-pickers/TimePicker";
+import dayjs from "dayjs";
+
+// Types matching the backend DTOs
+export type InspectionDTO = {
+  inspectionId: number;
+  inspectionTime: string; // ISO string from backend
+  branch: string;
+  inspector: string;
+  createdAt: string;
+  updatedAt: string;
+  transformerNo: string;
+};
+
+export interface AddInspectionDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: (inspectionData: {
+    branch: string;
+    transformerNo: string;
+    inspector: string;
+    inspectionTime: string;
+  }) => Promise<void>;
+  isCreating?: boolean;
+}
+
+export const AddInspectionDialog: React.FC<AddInspectionDialogProps> = ({
+  open,
+  onClose,
+  onConfirm,
+  isCreating = false,
+}) => {
+  // Dialog state
+  const [branch, setBranch] = React.useState("");
+  const [transformerNo, setTransformerNo] = React.useState("");
+  const [date, setDate] = React.useState("");
+  const [time, setTime] = React.useState("");
+  const [inspector, setInspector] = React.useState("");
+
+  // Validation
+  const canConfirm =
+    branch.trim() && transformerNo.trim() && date && time && inspector.trim();
+
+  // Reset form when dialog closes
+  React.useEffect(() => {
+    if (!open) {
+      setBranch("");
+      setTransformerNo("");
+      setDate("");
+      setTime("");
+      setInspector("");
+    }
+  }, [open]);
+
+  const handleClose = () => {
+    onClose();
+  };
+
+  const handleConfirm = async () => {
+    if (!canConfirm) return;
+
+    try {
+      // Format date correctly for backend (remove milliseconds and timezone)
+      const inspectionTime = new Date(`${date}T${time}`)
+        .toISOString()
+        .split(".")[0];
+
+      const newInspection = {
+        branch: branch.trim(),
+        transformerNo: transformerNo.trim(),
+        inspector: inspector.trim(),
+        inspectionTime,
+      };
+
+      await onConfirm(newInspection);
+    } catch (error) {
+      // Error handling is done by parent component
+      console.error("Error in AddInspectionDialog:", error);
+    }
+  };
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        fullWidth
+        maxWidth="sm"
+        PaperProps={{ sx: { borderRadius: 2 } }}
+      >
+        <DialogTitle
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
+          <Typography fontWeight={700} fontSize="1.25rem">
+            New Inspection
+          </Typography>
+          <IconButton onClick={handleClose} size="small">
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+
+        <DialogContent dividers sx={{ bgcolor: "#FBFBFE" }}>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <TextField
+              label="Branch"
+              placeholder="Branch"
+              fullWidth
+              value={branch}
+              onChange={(e) => setBranch(e.target.value)}
+            />
+
+            <TextField
+              label="Transformer No"
+              placeholder="Transformer No"
+              fullWidth
+              value={transformerNo}
+              onChange={(e) => setTransformerNo(e.target.value)}
+            />
+
+            <TextField
+              label="Inspector"
+              placeholder="Inspector Name"
+              fullWidth
+              value={inspector}
+              onChange={(e) => setInspector(e.target.value)}
+            />
+
+            <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+              <DatePicker
+                label="Date of Inspection"
+                value={date ? dayjs(date) : null}
+                onChange={(v) => setDate(v ? v.format("YYYY-MM-DD") : "")}
+                slotProps={{
+                  textField: { fullWidth: true },
+                  openPickerButton: {
+                    onMouseDown: (e) => e.preventDefault(),
+                    disableRipple: true,
+                    disableFocusRipple: true,
+                  },
+                }}
+              />
+              <TimePicker
+                label="Time"
+                value={time ? dayjs(`1970-01-01T${time}`) : null}
+                onChange={(v) => setTime(v ? v.format("HH:mm") : "")}
+                slotProps={{
+                  textField: { fullWidth: true },
+                  openPickerButton: {
+                    onMouseDown: (e) => e.preventDefault(),
+                    disableRipple: true,
+                    disableFocusRipple: true,
+                  },
+                }}
+              />
+            </Stack>
+          </Stack>
+        </DialogContent>
+
+        <DialogActions sx={{ px: 3, py: 2 }}>
+          <Button
+            variant="contained"
+            onClick={handleConfirm}
+            disabled={!canConfirm || isCreating}
+            sx={{
+              mr: 1,
+              borderRadius: 999,
+              px: 3,
+              py: 1,
+              fontWeight: 700,
+              textTransform: "none",
+              background: "linear-gradient(180deg, #4F46E5 0%, #2E26C3 100%)",
+              color: "#fff",
+              boxShadow: "0 8px 18px rgba(79,70,229,0.35)",
+              "&:hover": {
+                background: "linear-gradient(180deg, #4338CA 0%, #2A21B8 100%)",
+                boxShadow: "0 10px 22px rgba(79,70,229,0.45)",
+              },
+              "&.Mui-disabled": {
+                background: "#A5B4FC",
+                color: "#fff",
+              },
+            }}
+          >
+            {isCreating ? (
+              <CircularProgress size={20} color="inherit" />
+            ) : (
+              "Confirm"
+            )}
+          </Button>
+
+          <Button onClick={handleClose} sx={{ textTransform: "none" }}>
+            Cancel
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </LocalizationProvider>
+  );
+};
+
+export default AddInspectionDialog;

--- a/transformer-dashboard/src/models/DeleteInspectionConfirmationDialog.tsx
+++ b/transformer-dashboard/src/models/DeleteInspectionConfirmationDialog.tsx
@@ -1,0 +1,104 @@
+import * as React from "react";
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Typography,
+} from "@mui/material";
+import { Close as CloseIcon } from "@mui/icons-material";
+
+export interface DeleteInspectionConfirmationDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: (id: number) => Promise<void>;
+  inspectionId: number | null;
+  isDeleting?: boolean;
+}
+
+export const DeleteInspectionConfirmationDialog: React.FC<DeleteInspectionConfirmationDialogProps> = ({
+  open,
+  onClose,
+  onConfirm,
+  inspectionId,
+  isDeleting = false,
+}) => {
+  const handleClose = () => {
+    onClose();
+  };
+
+  const handleConfirm = async () => {
+    if (inspectionId === null) return;
+
+    try {
+      await onConfirm(inspectionId);
+    } catch (error) {
+      // Error handling is done by parent component
+      console.error("Error in DeleteInspectionConfirmationDialog:", error);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth="xs"
+      fullWidth
+      PaperProps={{ sx: { borderRadius: 2 } }}
+    >
+      <DialogTitle
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <Typography fontWeight={700} fontSize="1.25rem">
+          Confirm Delete
+        </Typography>
+        <IconButton onClick={handleClose} size="small">
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+
+      <DialogContent>
+        <Typography>
+          Are you sure you want to delete this inspection? This action cannot
+          be undone.
+        </Typography>
+      </DialogContent>
+
+      <DialogActions sx={{ px: 3, py: 2 }}>
+        <Button
+          variant="contained"
+          color="error"
+          onClick={handleConfirm}
+          disabled={isDeleting}
+          sx={{
+            mr: 1,
+            borderRadius: 999,
+            px: 3,
+            py: 1,
+            fontWeight: 700,
+            textTransform: "none",
+          }}
+        >
+          {isDeleting ? (
+            <CircularProgress size={20} color="inherit" />
+          ) : (
+            "Delete"
+          )}
+        </Button>
+
+        <Button onClick={handleClose} sx={{ textTransform: "none" }}>
+          Cancel
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default DeleteInspectionConfirmationDialog;

--- a/transformer-dashboard/src/models/DeleteTransformerConfirmationDialog.tsx
+++ b/transformer-dashboard/src/models/DeleteTransformerConfirmationDialog.tsx
@@ -1,0 +1,192 @@
+import * as React from "react";
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Paper,
+  Stack,
+  Typography,
+} from "@mui/material";
+import {
+  Warning as WarningIcon,
+  Close as CloseIcon,
+} from "@mui/icons-material";
+
+// Types matching the Dashboard component
+export type TransformerType = "Bulk" | "Distribution";
+
+export interface Transformer {
+  id?: number;
+  transformerNo: string;
+  poleNo: string;
+  region: string;
+  type: TransformerType;
+  favorite?: boolean;
+  location?: string;
+}
+
+export interface DeleteTransformerConfirmationDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => Promise<void>;
+  transformer: Transformer | null;
+  isDeleting?: boolean;
+}
+
+export const DeleteTransformerConfirmationDialog: React.FC<DeleteTransformerConfirmationDialogProps> = ({
+  open,
+  onClose,
+  onConfirm,
+  transformer,
+  isDeleting = false,
+}) => {
+  const handleClose = () => {
+    if (!isDeleting) {
+      onClose();
+    }
+  };
+
+  const handleConfirm = async () => {
+    try {
+      await onConfirm();
+      // Parent component will handle closing the dialog on success
+    } catch (error) {
+      // Error handling is done by the parent component
+      console.error("Error deleting transformer:", error);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth="xs"
+      fullWidth
+      PaperProps={{
+        sx: {
+          borderRadius: 2,
+        },
+      }}
+    >
+      <DialogTitle sx={{ pb: 1 }}>
+        <Stack
+          direction="row"
+          alignItems="center"
+          justifyContent="space-between"
+        >
+          <Stack direction="row" alignItems="center" spacing={1}>
+            <WarningIcon color="error" />
+            <Typography variant="h6" component="span">
+              Confirm Delete
+            </Typography>
+          </Stack>
+          <IconButton onClick={handleClose} size="small" disabled={isDeleting}>
+            <CloseIcon />
+          </IconButton>
+        </Stack>
+      </DialogTitle>
+      <DialogContent sx={{ pt: 1 }}>
+        <Typography variant="body1" sx={{ mb: 2 }}>
+          Are you sure you want to delete this transformer?
+        </Typography>
+
+        {transformer && (
+          <Paper
+            sx={{
+              p: 2,
+              bgcolor: "grey.50",
+              border: "1px solid",
+              borderColor: "grey.200",
+              borderRadius: 2,
+            }}
+          >
+            <Stack spacing={1}>
+              <Stack direction="row" justifyContent="space-between">
+                <Typography variant="body2" color="text.secondary">
+                  Transformer No:
+                </Typography>
+                <Typography variant="body2" fontWeight={600}>
+                  {transformer.transformerNo}
+                </Typography>
+              </Stack>
+              <Stack direction="row" justifyContent="space-between">
+                <Typography variant="body2" color="text.secondary">
+                  Pole No:
+                </Typography>
+                <Typography variant="body2" fontWeight={600}>
+                  {transformer.poleNo}
+                </Typography>
+              </Stack>
+              <Stack direction="row" justifyContent="space-between">
+                <Typography variant="body2" color="text.secondary">
+                  Region:
+                </Typography>
+                <Typography variant="body2" fontWeight={600}>
+                  {transformer.region}
+                </Typography>
+              </Stack>
+              <Stack direction="row" justifyContent="space-between">
+                <Typography variant="body2" color="text.secondary">
+                  Type:
+                </Typography>
+                <Typography variant="body2" fontWeight={600}>
+                  {transformer.type}
+                </Typography>
+              </Stack>
+              {transformer.location && (
+                <Stack direction="row" justifyContent="space-between">
+                  <Typography variant="body2" color="text.secondary">
+                    Location:
+                  </Typography>
+                  <Typography
+                    variant="body2"
+                    fontWeight={600}
+                    sx={{ maxWidth: "60%", textAlign: "right" }}
+                  >
+                    {transformer.location}
+                  </Typography>
+                </Stack>
+              )}
+            </Stack>
+          </Paper>
+        )}
+
+        <Typography
+          variant="body2"
+          color="error"
+          sx={{ mt: 2, fontStyle: "italic" }}
+        >
+          This action cannot be undone.
+        </Typography>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2.5, pt: 1 }}>
+        <Button onClick={handleClose} disabled={isDeleting} sx={{ mr: 1 }}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          color="error"
+          onClick={handleConfirm}
+          disabled={isDeleting}
+          sx={{
+            minWidth: 100,
+            background: "linear-gradient(45deg, #f44336 30%, #d32f2f 90%)",
+            "&:hover": {
+              background: "linear-gradient(45deg, #d32f2f 30%, #b71c1c 90%)",
+            },
+          }}
+        >
+          {isDeleting ? (
+            <CircularProgress size={20} color="inherit" />
+          ) : (
+            "Delete"
+          )}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/transformer-dashboard/src/models/EditInspectionDialog.tsx
+++ b/transformer-dashboard/src/models/EditInspectionDialog.tsx
@@ -1,0 +1,266 @@
+import * as React from "react";
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Close as CloseIcon } from "@mui/icons-material";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import { DatePicker } from "@mui/x-date-pickers/DatePicker";
+import { TimePicker } from "@mui/x-date-pickers/TimePicker";
+import dayjs from "dayjs";
+
+// Types matching the backend DTOs
+export type ImageStatus = "baseline" | "maintenance" | "no image";
+
+export type InspectionRow = {
+  id: number;
+  transformerNo: string;
+  inspectionNo: string;
+  inspectedDate: string;
+  maintenanceDate: string;
+  status: ImageStatus;
+  branch: string;
+  inspector: string;
+  inspectionTime: string;
+};
+
+export interface EditInspectionDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSave: (
+    id: number,
+    inspectionData: {
+      branch: string;
+      transformerNo: string;
+      inspector: string;
+      inspectionTime: string;
+    }
+  ) => Promise<void>;
+  inspectionData: InspectionRow | null;
+  isSaving?: boolean;
+}
+
+export const EditInspectionDialog: React.FC<EditInspectionDialogProps> = ({
+  open,
+  onClose,
+  onSave,
+  inspectionData,
+  isSaving = false,
+}) => {
+  // Dialog state
+  const [editBranch, setEditBranch] = React.useState("");
+  const [editTransformerNo, setEditTransformerNo] = React.useState("");
+  const [editDate, setEditDate] = React.useState("");
+  const [editTime, setEditTime] = React.useState("");
+  const [editInspector, setEditInspector] = React.useState("");
+  const [editStatus, setEditStatus] = React.useState<ImageStatus>("no image");
+
+  // Validation
+  const canSave =
+    editBranch.trim() &&
+    editTransformerNo.trim() &&
+    editDate &&
+    editTime &&
+    editInspector.trim();
+
+  // Initialize form with inspection data when dialog opens
+  React.useEffect(() => {
+    if (open && inspectionData) {
+      setEditBranch(inspectionData.branch);
+      setEditTransformerNo(inspectionData.transformerNo);
+      setEditInspector(inspectionData.inspector);
+      setEditStatus(inspectionData.status);
+
+      // Parse the ISO string back to date and time
+      const inspectionDate = new Date(inspectionData.inspectionTime);
+      setEditDate(inspectionDate.toISOString().split("T")[0]); // yyyy-mm-dd
+      setEditTime(inspectionDate.toTimeString().slice(0, 5)); // hh:mm
+    }
+  }, [open, inspectionData]);
+
+  // Reset form when dialog closes
+  React.useEffect(() => {
+    if (!open) {
+      setEditBranch("");
+      setEditTransformerNo("");
+      setEditDate("");
+      setEditTime("");
+      setEditInspector("");
+      setEditStatus("no image");
+    }
+  }, [open]);
+
+  const handleClose = () => {
+    onClose();
+  };
+
+  const handleSave = async () => {
+    if (!canSave || !inspectionData) return;
+
+    try {
+      // Format date correctly for backend (remove milliseconds and timezone)
+      const inspectionTime = new Date(`${editDate}T${editTime}`)
+        .toISOString()
+        .split(".")[0];
+
+      const updates = {
+        branch: editBranch.trim(),
+        transformerNo: editTransformerNo.trim(),
+        inspector: editInspector.trim(),
+        inspectionTime,
+      };
+
+      await onSave(inspectionData.id, updates);
+    } catch (error) {
+      // Error handling is done by parent component
+      console.error("Error in EditInspectionDialog:", error);
+    }
+  };
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        fullWidth
+        maxWidth="sm"
+        PaperProps={{ sx: { borderRadius: 2 } }}
+      >
+        <DialogTitle
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
+          <Typography fontWeight={700} fontSize="1.25rem">
+            Edit Inspection
+          </Typography>
+          <IconButton onClick={handleClose} size="small">
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+
+        <DialogContent dividers sx={{ bgcolor: "#FBFBFE" }}>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <TextField
+              label="Branch"
+              placeholder="Branch"
+              fullWidth
+              value={editBranch}
+              onChange={(e) => setEditBranch(e.target.value)}
+            />
+
+            <TextField
+              label="Transformer No"
+              placeholder="Transformer No"
+              fullWidth
+              value={editTransformerNo}
+              onChange={(e) => setEditTransformerNo(e.target.value)}
+            />
+
+            <TextField
+              label="Inspector"
+              placeholder="Inspector Name"
+              fullWidth
+              value={editInspector}
+              onChange={(e) => setEditInspector(e.target.value)}
+            />
+
+            <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+              <DatePicker
+                label="Date of Inspection"
+                value={editDate ? dayjs(editDate) : null}
+                onChange={(v) => setEditDate(v ? v.format("YYYY-MM-DD") : "")}
+                slotProps={{
+                  textField: { fullWidth: true },
+                  openPickerButton: {
+                    onMouseDown: (e) => e.preventDefault(),
+                    disableRipple: true,
+                    disableFocusRipple: true,
+                  },
+                }}
+              />
+              <TimePicker
+                label="Time"
+                value={editTime ? dayjs(`1970-01-01T${editTime}`) : null}
+                onChange={(v) => setEditTime(v ? v.format("HH:mm") : "")}
+                slotProps={{
+                  textField: { fullWidth: true },
+                  openPickerButton: {
+                    onMouseDown: (e) => e.preventDefault(),
+                    disableRipple: true,
+                    disableFocusRipple: true,
+                  },
+                }}
+              />
+            </Stack>
+
+            <Select
+              label="Status"
+              value={editStatus}
+              onChange={(e) => setEditStatus(e.target.value as ImageStatus)}
+              fullWidth
+              displayEmpty
+              renderValue={(value) => value || "Select Status"}
+            >
+              <MenuItem value="baseline">Baseline</MenuItem>
+              <MenuItem value="maintenance">Maintenance</MenuItem>
+              <MenuItem value="no image">No Image</MenuItem>
+            </Select>
+          </Stack>
+        </DialogContent>
+
+        <DialogActions sx={{ px: 3, py: 2 }}>
+          <Button
+            variant="contained"
+            onClick={handleSave}
+            disabled={!canSave || isSaving}
+            sx={{
+              mr: 1,
+              borderRadius: 999,
+              px: 3,
+              py: 1,
+              fontWeight: 700,
+              textTransform: "none",
+              background: "linear-gradient(180deg, #4F46E5 0%, #2E26C3 100%)",
+              color: "#fff",
+              boxShadow: "0 8px 18px rgba(79,70,229,0.35)",
+              "&:hover": {
+                background: "linear-gradient(180deg, #4338CA 0%, #2A21B8 100%)",
+                boxShadow: "0 10px 22px rgba(79,70,229,0.45)",
+              },
+              "&.Mui-disabled": {
+                background: "#A5B4FC",
+                color: "#fff",
+              },
+            }}
+          >
+            {isSaving ? (
+              <CircularProgress size={20} color="inherit" />
+            ) : (
+              "Save Changes"
+            )}
+          </Button>
+
+          <Button onClick={handleClose} sx={{ textTransform: "none" }}>
+            Cancel
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </LocalizationProvider>
+  );
+};
+
+export default EditInspectionDialog;

--- a/transformer-dashboard/src/pages/Dashboard.tsx
+++ b/transformer-dashboard/src/pages/Dashboard.tsx
@@ -57,6 +57,7 @@ import { useNavigate } from "react-router-dom";
 import Inspections from "./Inspections";
 import { AddTransformerDialog, type TransformerFormData } from "../models/AddEditTransformerDialog";
 import { DeleteTransformerConfirmationDialog } from "../models/DeleteTransformerConfirmationDialog";
+import "../styles/Dashboard.css";
 
 /* Types */
 type TransformerType = "Bulk" | "Distribution";
@@ -433,15 +434,15 @@ export default function Dashboard() {
 
   /* Drawer */
   const drawer = (
-    <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
-      <Stack direction="row" alignItems="center" spacing={1} sx={{ p: 2 }}>
+    <Box className="dashboard-drawer">
+      <Stack direction="row" alignItems="center" spacing={1} className="dashboard-logo-container">
         <BoltIcon />
-        <Typography variant="h6" fontWeight={800}>
+        <Typography variant="h6" className="dashboard-logo-text">
           PowerLens
         </Typography>
       </Stack>
       <Divider />
-      <List sx={{ p: 1 }}>
+      <List className="dashboard-nav-list">
         <ListItem disablePadding>
           <ListItemButton
             selected={view === "transformers"}
@@ -462,7 +463,7 @@ export default function Dashboard() {
           </ListItemButton>
         </ListItem>
       </List>
-      <Box sx={{ flexGrow: 1 }} />
+      <Box className="dashboard-flex-grow" />
     </Box>
   );
 
@@ -473,24 +474,18 @@ export default function Dashboard() {
         position="fixed"
         color="inherit"
         elevation={0}
-        sx={{
-          bgcolor: "background.paper",
-          borderBottom: (t) => `1px solid ${t.palette.divider}`,
-          ml: { sm: `${drawerWidth}px` },
-          width: { sm: `calc(100% - ${drawerWidth}px)` },
-          borderRadius: 0,   
-        }}
+        className="dashboard-app-header"
       >
-        <Toolbar sx={{ minHeight: 72 }}>
+        <Toolbar className="dashboard-toolbar">
           <Stack direction="row" spacing={1.25} alignItems="center">
             <IconButton onClick={() => setMobileOpen(!mobileOpen)}>
               <MenuIcon />
             </IconButton>
-            <Typography variant="h6" sx={{ fontWeight: 800 }}>
+            <Typography variant="h6" className="dashboard-toolbar-title">
               Transformers
             </Typography>
           </Stack>
-          <Box sx={{ flexGrow: 1 }} />
+          <Box className="dashboard-flex-grow" />
           <Tooltip title="Notifications">
             <IconButton>
               <Badge color="secondary" variant="dot">
@@ -502,14 +497,14 @@ export default function Dashboard() {
             direction="row"
             spacing={1.25}
             alignItems="center"
-            sx={{ ml: 1 }}
+            className="dashboard-user-stack"
           >
             <Avatar
               src="./user.png"
-              sx={{ width: 36, height: 36 }}
+              className="dashboard-user-avatar"
             />
-            <Box sx={{ display: { xs: "none", md: "block" } }}>
-              <Typography variant="subtitle2" sx={{ lineHeight: 1 }}>
+            <Box className="dashboard-user-info">
+              <Typography variant="subtitle2" className="dashboard-user-name">
                 Test User
               </Typography>
               <Typography variant="caption" color="text.secondary">
@@ -531,12 +526,13 @@ export default function Dashboard() {
           open={mobileOpen}
           onClose={() => setMobileOpen(false)}
           ModalProps={{ keepMounted: true }}
+          className="dashboard-drawer-temporary"
           sx={{
             display: { xs: "block", sm: "none" },
             "& .MuiDrawer-paper": {
               boxSizing: "border-box",
               width: drawerWidth,
-              borderRadius: 0,      
+              borderRadius: 0,
             },
           }}
         >
@@ -544,12 +540,13 @@ export default function Dashboard() {
         </Drawer>
         <Drawer
           variant="permanent"
+          className="dashboard-drawer-permanent"
           sx={{
             display: { xs: "none", sm: "block" },
             "& .MuiDrawer-paper": {
               boxSizing: "border-box",
               width: drawerWidth,
-              borderRadius: 0,      
+              borderRadius: 0,
             },
           }}
           open
@@ -562,37 +559,23 @@ export default function Dashboard() {
       <Box sx={{ display: "flex", bgcolor: "background.default" }}>
         <Box
           component="main"
-          sx={{
-            flexGrow: 1,
-            p: { xs: 2, sm: 1 },
-            mt: 9,
-            ml: { sm: `${drawerWidth}px` },
-          }}
+          className="dashboard-main-content"
         >
           {view === "transformers" ? (
             <Stack spacing={2}>
               {/* Section header card */}
-              <Paper elevation={3} sx={{ p: 2, borderRadius: 1 }}>
+              <Paper elevation={3} className="dashboard-header-card">
                 <Stack
                   direction={{ xs: "column", md: "row" }}
                   spacing={2}
                   alignItems={{ xs: "stretch", md: "center" }}
+                  className="dashboard-header-stack"
                 >
                   <Stack direction="row" spacing={1.25} alignItems="center">
-                    <Box
-                      sx={{
-                        bgcolor: "primary.main",
-                        color: "primary.contrastText",
-                        fontWeight: 700,
-                        borderRadius: 2,
-                        px: 1.2,
-                        py: 0.4,
-                        boxShadow: "0 6px 16px rgba(79,70,229,0.25)",
-                      }}
-                    >
+                    <Box className="dashboard-count-badge">
                       {filtered.length}
                     </Box>
-                    <Typography variant="h6" sx={{ fontWeight: 700 }}>
+                    <Typography variant="h6" className="dashboard-section-title">
                       Transformers
                     </Typography>
                   </Stack>
@@ -600,29 +583,14 @@ export default function Dashboard() {
                     variant="contained"
                     startIcon={<AddIcon />}
                     onClick={openAddDialog}
-                    sx={{
-                      ml: { md: 1 },
-                      borderRadius: 999,
-                      px: 2.5,
-                      py: 0.9,
-                      fontWeight: 700,
-                      textTransform: "none",
-                      background:
-                        "linear-gradient(180deg, #4F46E5 0%, #2E26C3 100%)",
-                      boxShadow: "0 8px 18px rgba(79,70,229,0.35)",
-                      "&:hover": {
-                        background:
-                          "linear-gradient(180deg, #4338CA 0%, #2A21B8 100%)",
-                        boxShadow: "0 10px 22px rgba(79,70,229,0.45)",
-                      },
-                    }}
+                    className="dashboard-add-button"
                   >
                     Add Transformer
                   </Button>
 
                   {/* Pill toggle on the right side */}
-                  <Box sx={{ flexGrow: 1 }} />
-                  <Paper elevation={3} sx={{ p: 0.5, borderRadius: 999 }}>
+                  <Box className="dashboard-flex-grow" />
+                  <Paper elevation={3} className="dashboard-toggle-paper">
                     <ToggleButtonGroup
                       value={view}
                       exclusive
@@ -642,27 +610,15 @@ export default function Dashboard() {
                     >
                       <ToggleButton
                         value="transformers"
-                        sx={{
-                          bgcolor:
-                            view === "transformers"
-                              ? "primary.main"
-                              : "transparent",
-                          color:
-                            view === "transformers"
-                              ? "primary.contrastText"
-                              : "text.primary",
-                          "&:hover": {
-                            bgcolor:
-                              view === "transformers"
-                                ? "primary.dark"
-                                : "action.hover",
-                          },
-                        }}
+                        className={`dashboard-toggle-button ${
+                          view === "transformers" ? "dashboard-toggle-button-active" : ""
+                        }`}
                       >
                         Transformers
                       </ToggleButton>
                       <ToggleButton
                         value="inspections"
+                        className="dashboard-toggle-button"
                       >
                         Inspections
                       </ToggleButton>
@@ -675,7 +631,7 @@ export default function Dashboard() {
                   direction={{ xs: "column", lg: "row" }}
                   spacing={2}
                   alignItems="center"
-                  sx={{ mt: 2 }}
+                  className="dashboard-filter-container"
                 >
                   <TextField
                     fullWidth
@@ -695,7 +651,7 @@ export default function Dashboard() {
                     size="small"
                     value={region}
                     onChange={(e) => setRegion(e.target.value)}
-                    sx={{ minWidth: 180 }}
+                    className="dashboard-filter-select"
                   >
                     <MenuItem value="All">All Regions</MenuItem>
                     {REGIONS.map((r) => (
@@ -708,7 +664,7 @@ export default function Dashboard() {
                     size="small"
                     value={ttype}
                     onChange={(e) => setTtype(e.target.value as TransformerType | "All")}
-                    sx={{ minWidth: 180 }}
+                    className="dashboard-filter-select"
                   >
                     <MenuItem value="All">All Types</MenuItem>
                     {TYPES.map((t) => (
@@ -719,7 +675,7 @@ export default function Dashboard() {
                   </Select>
                   <Stack direction="row" alignItems="center" spacing={1}>
                     <StarIcon
-                      sx={{ fontSize: 18 }}
+                      className="dashboard-star-icon"
                       color={onlyFav ? "secondary" : "disabled"}
                     />
                     <Switch
@@ -730,7 +686,7 @@ export default function Dashboard() {
                       Favorites only
                     </Typography>
                   </Stack>
-                  <Button onClick={resetFilters} sx={{ textTransform: "none" }}>
+                  <Button onClick={resetFilters} className="dashboard-reset-filters">
                     Reset Filters
                   </Button>
                 </Stack>
@@ -739,13 +695,13 @@ export default function Dashboard() {
               {/* Table */}
               <Paper>
                 {loading ? (
-                  <Box sx={{ p: 4, textAlign: "center" }}>
+                  <Box className="dashboard-loading-container">
                     <CircularProgress />
                   </Box>
                 ) : error ? (
-                  <Box sx={{ p: 4, textAlign: "center" }}>
+                  <Box className="dashboard-error-container">
                     <Typography color="error">{error}</Typography>
-                    <Button onClick={fetchTransformers} sx={{ mt: 2 }}>
+                    <Button onClick={fetchTransformers} className="dashboard-retry-button">
                       Retry
                     </Button>
                   </Box>
@@ -768,13 +724,13 @@ export default function Dashboard() {
                                 }
                                 onClick={handleRequestSort("transformerNo")}
                               >
-                                Transformer No.
+                                <Typography fontWeight="bold">Transformer No.</Typography>
                               </TableSortLabel>
                             </TableCell>
-                            <TableCell>Pole No.</TableCell>
-                            <TableCell>Region</TableCell>
-                            <TableCell>Type</TableCell>
-                            <TableCell align="right">Actions</TableCell>
+                            <TableCell><Typography fontWeight="bold">Pole No.</Typography></TableCell>
+                            <TableCell><Typography fontWeight="bold">Region</Typography></TableCell>
+                            <TableCell><Typography fontWeight="bold">Type</Typography></TableCell>
+                            <TableCell align="right"></TableCell>
                           </TableRow>
                         </TableHead>
                         <TableBody>
@@ -801,14 +757,14 @@ export default function Dashboard() {
                                   spacing={1}
                                   alignItems="center"
                                 >
-                                  <Typography fontWeight={600}>
+                                  <Typography className="dashboard-transformer-number">
                                     {row.transformerNo}
                                   </Typography>
                                   <Chip
                                     size="small"
                                     label="↓"
                                     variant="outlined"
-                                    sx={{ borderRadius: 1 }}
+                                    className="dashboard-chip-arrow"
                                   />
                                 </Stack>
                               </TableCell>
@@ -855,7 +811,7 @@ export default function Dashboard() {
                           {paged.length === 0 && (
                             <TableRow>
                               <TableCell colSpan={6}>
-                                <Box sx={{ p: 4, textAlign: "center" }}>
+                                <Box className="dashboard-no-results">
                                   <Typography>No results found</Typography>
                                 </Box>
                               </TableCell>
@@ -894,12 +850,7 @@ export default function Dashboard() {
         transformOrigin={{ horizontal: "right", vertical: "top" }}
         anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
         PaperProps={{
-          sx: {
-            mt: 1,
-            minWidth: 150,
-            boxShadow: "0 4px 20px rgba(0,0,0,0.1)",
-            borderRadius: 2,
-          },
+          className: "dashboard-action-menu",
         }}
       >
         <MenuItem
@@ -916,7 +867,7 @@ export default function Dashboard() {
           onClick={() =>
             selectedTransformer && openDeleteDialog(selectedTransformer)
           }
-          sx={{ color: "error.main" }}
+          className="dashboard-delete-menu-item"
         >
           <ListItemIcon>
             <DeleteIcon fontSize="small" color="error" />
@@ -955,11 +906,7 @@ export default function Dashboard() {
         <Alert
           onClose={handleCloseSnackbar}
           severity={snackbar.severity}
-          sx={{
-            width: "100%",
-            boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
-            borderRadius: 2,
-          }}
+          className="dashboard-snackbar-alert"
           variant="filled"
         >
           {snackbar.message}

--- a/transformer-dashboard/src/pages/Dashboard.tsx
+++ b/transformer-dashboard/src/pages/Dashboard.tsx
@@ -57,7 +57,7 @@ import { useNavigate } from "react-router-dom";
 import Inspections from "./Inspections";
 import { AddTransformerDialog, type TransformerFormData } from "../models/AddEditTransformerDialog";
 import { DeleteTransformerConfirmationDialog } from "../models/DeleteTransformerConfirmationDialog";
-import "../styles/Dashboard.css";
+import "../styles/dashboard.css";
 
 /* Types */
 type TransformerType = "Bulk" | "Distribution";

--- a/transformer-dashboard/src/pages/Inspections.tsx
+++ b/transformer-dashboard/src/pages/Inspections.tsx
@@ -50,7 +50,7 @@ import { useNavigate } from "react-router-dom";
 import AddInspectionDialog from "../models/AddInspectionDialog";
 import EditInspectionDialog from "../models/EditInspectionDialog";
 import DeleteInspectionConfirmationDialog from "../models/DeleteInspectionConfirmationDialog";
-import "../styles/Dashboard.css";
+import "../styles/dashboard.css";
 
 /* Props controlled by Dashboard */
 type Props = {

--- a/transformer-dashboard/src/pages/Inspections.tsx
+++ b/transformer-dashboard/src/pages/Inspections.tsx
@@ -46,6 +46,10 @@ import {
   Edit as EditIcon,
   Delete as DeleteIcon,
 } from "@mui/icons-material";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import { DatePicker } from "@mui/x-date-pickers/DatePicker";
+import dayjs from "dayjs";
 import { useNavigate } from "react-router-dom";
 
 /* Props controlled by Dashboard */
@@ -547,7 +551,8 @@ export default function Inspections({
   }
 
   return (
-    <>
+    // <>
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
       {/* <CssBaseline /> */}
 
       {/* Show error if any */}
@@ -996,13 +1001,19 @@ export default function Inspections({
             />
 
             <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
-              <TextField
+              {/* <TextField
                 label="Date of Inspection"
                 type="date"
                 fullWidth
                 value={date}
                 onChange={(e) => setDate(e.target.value)}
                 InputLabelProps={{ shrink: true }}
+              /> */}
+              <DatePicker
+                label="Date of Inspection"
+                value={date ? dayjs(date) : null}
+                onChange={(v) => setDate(v ? v.format("YYYY-MM-DD") : "")}
+                slotProps={{ textField: { fullWidth: true } }}
               />
               <TextField
                 label="Time"
@@ -1104,13 +1115,19 @@ export default function Inspections({
             />
 
             <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
-              <TextField
+              {/* <TextField
                 label="Date of Inspection"
                 type="date"
                 fullWidth
                 value={editDate}
                 onChange={(e) => setEditDate(e.target.value)}
                 InputLabelProps={{ shrink: true }}
+              /> */}
+              <DatePicker
+                label="Date of Inspection"
+                value={editDate ? dayjs(editDate) : null}
+                onChange={(v) => setEditDate(v ? v.format("YYYY-MM-DD") : "")}
+                slotProps={{ textField: { fullWidth: true } }}
               />
               <TextField
                 label="Time"
@@ -1234,6 +1251,7 @@ export default function Inspections({
           </Button>
         </DialogActions>
       </Dialog>
-    </>
+      </LocalizationProvider>
+    // </>
   );
 }

--- a/transformer-dashboard/src/pages/Inspections.tsx
+++ b/transformer-dashboard/src/pages/Inspections.tsx
@@ -1014,7 +1014,14 @@ export default function Inspections({
                 label="Date of Inspection"
                 value={date ? dayjs(date) : null}
                 onChange={(v) => setDate(v ? v.format("YYYY-MM-DD") : "")}
-                slotProps={{ textField: { fullWidth: true } }}
+                slotProps={{
+                  textField: { fullWidth: true },
+                  openPickerButton: {
+                    onMouseDown: (e) => e.preventDefault(),
+                    disableRipple: true,
+                    disableFocusRipple: true,
+                  },
+                }}
               />
               {/* <TextField
                 label="Time"
@@ -1028,7 +1035,14 @@ export default function Inspections({
                 label="Time"
                 value={time ? dayjs(`1970-01-01T${time}`) : null}
                 onChange={(v) => setTime(v ? v.format("HH:mm") : "")}
-                slotProps={{ textField: { fullWidth: true } }}
+                slotProps={{
+                  textField: { fullWidth: true },
+                  openPickerButton: {
+                    onMouseDown: (e) => e.preventDefault(),
+                    disableRipple: true,
+                    disableFocusRipple: true,
+                  },
+                }}
               />
             </Stack>
           </Stack>
@@ -1134,7 +1148,14 @@ export default function Inspections({
                 label="Date of Inspection"
                 value={editDate ? dayjs(editDate) : null}
                 onChange={(v) => setEditDate(v ? v.format("YYYY-MM-DD") : "")}
-                slotProps={{ textField: { fullWidth: true } }}
+                slotProps={{
+                  textField: { fullWidth: true },
+                  openPickerButton: {
+                    onMouseDown: (e) => e.preventDefault(),
+                    disableRipple: true,
+                    disableFocusRipple: true,
+                  },
+                }}
               />
               {/* <TextField
                 label="Time"
@@ -1148,7 +1169,15 @@ export default function Inspections({
                 label="Time"
                 value={editTime ? dayjs(`1970-01-01T${editTime}`) : null}
                 onChange={(v) => setEditTime(v ? v.format("HH:mm") : "")}
-                slotProps={{ textField: { fullWidth: true } }}
+                // slotProps={{ textField: { fullWidth: true } }}
+                slotProps={{
+                  textField: { fullWidth: true },
+                  openPickerButton: {
+                    onMouseDown: (e) => e.preventDefault(),
+                    disableRipple: true,
+                    disableFocusRipple: true,
+                  },
+                }}
               />
             </Stack>
 

--- a/transformer-dashboard/src/pages/Inspections.tsx
+++ b/transformer-dashboard/src/pages/Inspections.tsx
@@ -541,7 +541,6 @@ export default function Inspections({
   }
 
   return (
-    // <>
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       {/* <CssBaseline /> */}
 
@@ -924,6 +923,5 @@ export default function Inspections({
         isDeleting={deleting}
       />
       </LocalizationProvider>
-    // </>
   );
 }

--- a/transformer-dashboard/src/pages/Inspections.tsx
+++ b/transformer-dashboard/src/pages/Inspections.tsx
@@ -49,6 +49,7 @@ import {
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { DatePicker } from "@mui/x-date-pickers/DatePicker";
+import { TimePicker } from "@mui/x-date-pickers/TimePicker";
 import dayjs from "dayjs";
 import { useNavigate } from "react-router-dom";
 
@@ -1015,13 +1016,19 @@ export default function Inspections({
                 onChange={(v) => setDate(v ? v.format("YYYY-MM-DD") : "")}
                 slotProps={{ textField: { fullWidth: true } }}
               />
-              <TextField
+              {/* <TextField
                 label="Time"
                 type="time"
                 fullWidth
                 value={time}
                 onChange={(e) => setTime(e.target.value)}
                 InputLabelProps={{ shrink: true }}
+              /> */}
+              <TimePicker
+                label="Time"
+                value={time ? dayjs(`1970-01-01T${time}`) : null}
+                onChange={(v) => setTime(v ? v.format("HH:mm") : "")}
+                slotProps={{ textField: { fullWidth: true } }}
               />
             </Stack>
           </Stack>
@@ -1129,13 +1136,19 @@ export default function Inspections({
                 onChange={(v) => setEditDate(v ? v.format("YYYY-MM-DD") : "")}
                 slotProps={{ textField: { fullWidth: true } }}
               />
-              <TextField
+              {/* <TextField
                 label="Time"
                 type="time"
                 fullWidth
                 value={editTime}
                 onChange={(e) => setEditTime(e.target.value)}
                 InputLabelProps={{ shrink: true }}
+              /> */}
+              <TimePicker
+                label="Time"
+                value={editTime ? dayjs(`1970-01-01T${editTime}`) : null}
+                onChange={(v) => setEditTime(v ? v.format("HH:mm") : "")}
+                slotProps={{ textField: { fullWidth: true } }}
               />
             </Stack>
 

--- a/transformer-dashboard/src/styles/dashboard.css
+++ b/transformer-dashboard/src/styles/dashboard.css
@@ -1,0 +1,334 @@
+/* Dashboard CSS Styles */
+
+/* App Header Styles */
+.dashboard-app-header {
+  background-color: var(--mui-palette-background-paper);
+  border-bottom: 1px solid var(--mui-palette-divider);
+  margin-left: 260px;
+  width: calc(100% - 260px);
+  border-radius: 0;
+}
+
+@media (max-width: 600px) {
+  .dashboard-app-header {
+    margin-left: 0;
+    width: 100%;
+  }
+}
+
+.dashboard-toolbar {
+  min-height: 72px;
+}
+
+.dashboard-toolbar-title {
+  font-weight: 800;
+}
+
+.dashboard-user-avatar {
+  width: 36px;
+  height: 36px;
+}
+
+.dashboard-user-name {
+  line-height: 1;
+}
+
+.dashboard-user-stack {
+  margin-left: 8px;
+}
+
+.dashboard-flex-grow {
+  flex-grow: 1;
+}
+
+/* Drawer Styles */
+.dashboard-drawer {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.dashboard-drawer-paper {
+  box-sizing: border-box;
+  width: 260px;
+  border-radius: 0;
+}
+
+.dashboard-logo-container {
+  padding: 16px;
+}
+
+.dashboard-logo-text {
+  font-weight: 800;
+}
+
+.dashboard-nav-list {
+  padding: 8px;
+}
+
+/* Main Content Styles */
+.dashboard-main-content {
+  flex-grow: 1;
+  padding: 16px 8px;
+  margin-top: 72px;
+  margin-left: 260px;
+}
+
+@media (max-width: 600px) {
+  .dashboard-main-content {
+    padding: 16px;
+    margin-left: 0;
+  }
+}
+
+/* Inspections Page Specific */
+.dashboard-inspections-content {
+  margin-top: 0;
+  width: 100%;
+}
+
+.dashboard-inspections-stack {
+  width: 100%;
+}
+
+/* Header Card Styles */
+.dashboard-header-card {
+  padding: 16px;
+  border-radius: 8px;
+}
+
+.dashboard-header-card-full-width {
+  padding: 16px;
+  border-radius: 8px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.dashboard-count-badge {
+  background-color: var(--mui-palette-primary-main);
+  color: var(--mui-palette-primary-contrastText);
+  font-weight: 700;
+  border-radius: 16px;
+  padding: 3.2px 9.6px;
+  box-shadow: 0 6px 16px rgba(79, 70, 229, 0.25);
+}
+
+.dashboard-section-title {
+  font-weight: 700;
+}
+
+.dashboard-add-button {
+  margin-left: 8px;
+  border-radius: 9999px;
+  padding: 7.2px 20px;
+  font-weight: 700;
+  text-transform: none;
+  background: linear-gradient(180deg, #4F46E5 0%, #2E26C3 100%);
+  box-shadow: 0 8px 18px rgba(79, 70, 229, 0.35);
+}
+
+.dashboard-add-button:hover {
+  background: linear-gradient(180deg, #4338CA 0%, #2A21B8 100%);
+  box-shadow: 0 10px 22px rgba(79, 70, 229, 0.45);
+}
+
+@media (min-width: 900px) {
+  .dashboard-add-button {
+    margin-left: 8px;
+  }
+}
+
+.dashboard-toggle-paper {
+  padding: 4px;
+  border-radius: 9999px;
+}
+
+.dashboard-toggle-button {
+  border: 0 !important;
+  text-transform: none;
+  padding: 6.4px 17.6px;
+  border-radius: 9999px !important;
+  font-weight: 600;
+}
+
+.dashboard-toggle-button-active {
+  background-color: var(--mui-palette-primary-main) !important;
+  color: var(--mui-palette-primary-contrastText) !important;
+}
+
+.dashboard-toggle-button-active:hover {
+  background-color: var(--mui-palette-primary-dark) !important;
+}
+
+.dashboard-toggle-button:hover {
+  background-color: var(--mui-palette-action-hover);
+}
+
+/* Filter Styles */
+.dashboard-filter-container {
+  margin-top: 16px;
+}
+
+.dashboard-filter-select {
+  min-width: 180px;
+}
+
+.dashboard-star-icon {
+  font-size: 18px;
+}
+
+.dashboard-reset-filters {
+  text-transform: none;
+}
+
+/* Table Styles */
+.dashboard-loading-container {
+  padding: 32px;
+  text-align: center;
+}
+
+.dashboard-error-container {
+  padding: 32px;
+  text-align: center;
+}
+
+.dashboard-retry-button {
+  margin-top: 16px;
+}
+
+.dashboard-transformer-number {
+  font-weight: 600;
+}
+
+.dashboard-chip-arrow {
+  border-radius: 8px;
+}
+
+.dashboard-no-results {
+  padding: 32px;
+  text-align: center;
+}
+
+/* Action Menu Styles */
+.dashboard-action-menu {
+  margin-top: 8px;
+  min-width: 150px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  border-radius: 16px;
+}
+
+.dashboard-delete-menu-item {
+  color: var(--mui-palette-error-main);
+}
+
+/* Alert Styles */
+.dashboard-error-alert {
+  margin-bottom: 16px;
+}
+
+/* Snackbar Styles */
+.dashboard-snackbar-alert {
+  width: 100%;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  border-radius: 16px;
+}
+
+/* Responsive Design */
+@media (max-width: 600px) {
+  .dashboard-drawer-temporary {
+    display: block;
+  }
+  
+  .dashboard-drawer-permanent {
+    display: none;
+  }
+  
+  .dashboard-user-info {
+    display: none;
+  }
+}
+
+@media (min-width: 600px) {
+  .dashboard-drawer-temporary {
+    display: none;
+  }
+  
+  .dashboard-drawer-permanent {
+    display: block;
+  }
+}
+
+@media (min-width: 900px) {
+  .dashboard-user-info {
+    display: block;
+  }
+}
+
+/* Filter responsive layout */
+@media (max-width: 1200px) {
+  .dashboard-filter-container {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
+@media (min-width: 1200px) {
+  .dashboard-filter-container {
+    flex-direction: row;
+    align-items: center;
+  }
+}
+
+/* Header responsive layout */
+@media (max-width: 900px) {
+  .dashboard-header-stack {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
+@media (min-width: 900px) {
+  .dashboard-header-stack {
+    flex-direction: row;
+    align-items: center;
+  }
+}
+
+/* Inspections Page Specific Styles */
+.dashboard-app-header-fixed {
+  background-color: var(--mui-palette-background-paper) !important;
+  border-bottom: 1px solid var(--mui-palette-divider) !important;
+  border-radius: 0 !important;
+  margin-left: 260px;
+  width: calc(100% - 260px);
+}
+
+@media (max-width: 600px) {
+  .dashboard-app-header-fixed {
+    margin-left: 0;
+    width: 100%;
+  }
+}
+
+.dashboard-toolbar-inspections {
+  min-height: 72px;
+  justify-content: space-between;
+}
+
+.dashboard-app-title {
+  font-weight: 800 !important;
+}
+
+.dashboard-user-info {
+  margin-left: 8px;
+}
+
+.dashboard-user-details {
+  display: block;
+}
+
+@media (max-width: 900px) {
+  .dashboard-user-details {
+    display: none;
+  }
+}

--- a/transformer-dashboard/src/styles/dashboard.css
+++ b/transformer-dashboard/src/styles/dashboard.css
@@ -1,4 +1,4 @@
-/* Dashboard CSS Styles */
+/* dashboard CSS Styles */
 
 /* App Header Styles */
 .dashboard-app-header {


### PR DESCRIPTION
This pull request introduces support for marking inspections and transformers as "favorite" in both the backend and frontend, and adds new dialog components for creating, editing, and deleting inspections and transformers in the dashboard UI. The most important changes are grouped below.

### Backend: Favorite flag for inspections

* Added a `favorite` field to the `Inspection` entity and `InspectionDTO`, including database schema and baseline data updates to support this flag. [[1]](diffhunk://#diff-82450de22277cb330eb8af06ccbf6947c754f0251b1fb5ed6588f4def6f6651dR33-R35) [[2]](diffhunk://#diff-af38f6709fb2ceca73e1b2c7905bcf886c40eeef90bace679ff029be4505bb28R12) [[3]](diffhunk://#diff-52e8d113754cad1a1aa0740cddae902e383e8a681e25766da967a8b3caac26bfL13-R29)
* Updated the inspection update logic in `InspectionService` to allow updating the `favorite` flag via the API.

### Frontend: Inspections favorite support
* Added `favorite column` to provide a UI for adding and removing transformer inspections into favorite list.
<img width="1038" height="717" alt="image" src="https://github.com/user-attachments/assets/4ad224e0-b854-47ba-a3b2-3d3426c45731" />

### Frontend: Dialog components for dashboard operations
* Added `AddEditTransformerDialog` component to provide a UI for adding and editing transformers, including support for the `favorite` field.
* Added `DeleteTransformerConfirmationDialog` component to confirm and handle transformer deletions.
* Added `AddInspectionDialog` component for creating new inspections with date, time, and validation logic.
* Added `EditInspectionDialog` component for editing added inspections with validation logic.
* Added `DeleteInspectionConfirmationDialog` component to confirm and handle inspection deletions.

### Frontend: Minor changes
* Added `Date-picker`  and `Time-picker` components to provide a more robust UI support to enhance UX in both inspection and transformer management model dialogs.
<img width="745" height="500" alt="image" src="https://github.com/user-attachments/assets/2911cc45-a267-4cc2-b2af-6ab5ef81ad00" />